### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           # tags: ${{ steps.meta.outputs.tags }}
           
       - name: Publish to DockerHub
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: styxiik/ddcf
           username: styxiik


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore